### PR TITLE
feat/fix: improve makefile, package build scripts, rpm spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,42 +110,39 @@ uninstall:
 	@printf "Removing: $(DESTDIR)$(PREFIX)/share/$(NAME)\n"
 	@rm -rf $(DESTDIR)$(PREFIX)/share/$(NAME)
 
-	@-rm -rf $(DESTDIR)/etc/apparmor.d/kbd-backlight
+	@printf "Removing: $(DESTDIR)/etc/apparmor.d/$(NAME)\n"
+	@-rm -rf $(DESTDIR)/etc/apparmor.d/$(NAME)
 
 postinstall: install
 	@printf "Adding capability: cap_dac_override\n"
-	@setcap cap_dac_override+eip $(DESTDIR)$(PREFIX)/bin/kbd-backlight
+	@setcap cap_dac_override+eip $(DESTDIR)$(PREFIX)/bin/$(NAME)
 
 	@printf "Adding group: $(NAME)\n"
 	@-groupadd -r "$(NAME)"
 
 apparmor:
 	@printf "Installing AppArmor profile...\n"
-	@install -Dm644 files/apparmor.profile $(DESTDIR)/etc/apparmor.d/kbd-backlight
+	@install -Dm644 files/apparmor.profile $(DESTDIR)/etc/apparmor.d/$(NAME)
 
 # Build the deb package
 # make V="x.x.x" deb
 deb:
-	docker build -t kbd-backlight-deb packages/deb
+	docker build -t $(NAME)-deb packages/deb
 	docker run --rm -it \
 		-v $$PWD:/repo \
 		-e v=$(V) \
-		kbd-backlight-deb
+		$(NAME)-deb
 
 # Build the rpm src and bin packages
 # make V="x.x.x" rpm
-# NOTE: We use --privileged because otherwise docker
-#		wont let us do bind mounts inside the container
-#		This is just so we dont cp the entire repo for no reason
 rpm:
-	docker build -t kbd-backlight-rpm packages/rpm
+	docker build -t $(NAME)-rpm packages/rpm
 	docker run --rm -it \
-		--privileged \
 		-v $$PWD:/repo \
 		-e v=$(V) \
-		kbd-backlight-rpm
+		$(NAME)-rpm
 
 clean_docker:
-	docker rmi kbd-backlight-deb kbd-backlight-rpm
+	docker rmi $(NAME)-deb $(NAME)-rpm
 
 .PHONY: all banner info help setup build clean distclean install uninstall postinstall apparmor deb rpm

--- a/packages/deb/Dockerfile
+++ b/packages/deb/Dockerfile
@@ -4,9 +4,12 @@ FROM debian
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
-RUN apt-get install --no-install-recommends -y build-essential libc-dev gcc make cmake libconfig-dev git libcap2-bin
+RUN apt-get install --no-install-recommends -y \
+	build-essential libc-dev gcc make cmake \
+	libconfig-dev libcap2-bin git
 
 RUN mkdir -p /repo
+RUN git config --global --add safe.directory /repo
 
 WORKDIR /repo
 

--- a/packages/deb/entry.sh
+++ b/packages/deb/entry.sh
@@ -1,36 +1,26 @@
 #!/usr/bin/bash
 set -e
 
-export pkg_base_dir="/repo/packages/deb"
-export pkg_file="${pkg_base_dir}/DEBIAN/control"
-
-# Get property from package file (control or spec file)
 get_property() {
-	grep "$1:" "$pkg_file" | awk '{print $NF}'
+	awk "/^$1:/{print \$NF}" "$pkg_file"
 }
 
-arch="$(dpkg --print-architecture)"
+pkg_base_dir="/repo/packages/deb"
+pkg_file="${pkg_base_dir}/DEBIAN/control"
 name="$(get_property Package)"
-
-# Use version from V if its valid,
-# otherwise use commit id
-if [ "$v" ]; then
-	version="$v"
-else
-	version="$(git rev-parse --short HEAD)"
-fi
-
+version="${v:-$(git rev-parse --short HEAD)}"
+arch="$(dpkg --print-architecture)"
 fullname="${name}_${version}_${arch}"
 
 make PREFIX="/usr" DESTDIR="/tmp/$fullname" distclean all install apparmor
 
 cp -r "$pkg_base_dir/DEBIAN" "/tmp/$fullname"
-cd "/tmp/$fullname/DEBIAN" || exit
+cd "/tmp/$fullname/DEBIAN"
 sed -i "s/VERSION_NUMBER/$version/g" control
-sed -i "s/INSTALLED_SIZE/$install_size/g" control
 
 install_size="$(du -bc "/tmp/$fullname" | tail -n1 | awk '{print $1}')"
 
+sed -i "s/INSTALLED_SIZE/$install_size/g" control
 mkdir -p "$pkg_base_dir/out"
 cd "$pkg_base_dir/out"
 

--- a/packages/rpm/Dockerfile
+++ b/packages/rpm/Dockerfile
@@ -1,12 +1,14 @@
 FROM fedora
 
 RUN dnf -y update
-RUN dnf -y install rpm-build rpm-devel rpmlint rpmdevtools \
-	make cmake gcc gcc-c++ g++ libconfig libconfig-devel git
+RUN dnf -y install rpm-build rpm-devel rpmlint \
+	rpmdevtools systemd-rpm-macros make cmake \
+	gcc gcc-c++ g++ libconfig libconfig-devel git
 
 RUN rpmdev-setuptree
 
 RUN mkdir -p /repo
+RUN git config --global --add safe.directory /repo
 
 WORKDIR /repo
 

--- a/packages/rpm/entry.sh
+++ b/packages/rpm/entry.sh
@@ -1,45 +1,31 @@
 #!/usr/bin/bash
 set -e
 
-export pkg_base_dir="/repo/packages/rpm"
-export pkg_file="${pkg_base_dir}/package.spec"
-
-# Get property from package file (control or spec file)
 get_property() {
-	grep "$1:" "$pkg_file" | awk '{print $NF}'
+	awk "/^$1:/{print \$NF}" "$pkg_file"
 }
 
-
+pkg_base_dir="/repo/packages/rpm"
+pkg_file="${pkg_base_dir}/package.spec"
 name="$(get_property Name)"
+version="${v:-$(git rev-parse --short HEAD)}"
+release="$(rpm -E "$(get_property Release)")"
+arch="$(arch)"
+fullname="$name-$version-$release"
 
-# Use version from V if its valid,
-# otherwise use commit id
-if [ "$v" ]; then
-	version="$v"
-else
-	version="$(git rev-parse --short HEAD)"
-fi
+git archive --format "tar.gz" --prefix "$name-$version/" \
+	-o "$HOME/rpmbuild/SOURCES/$name-$version.tar.gz" HEAD
 
-cd /tmp
-mkdir -p "$name-$version"
-# Do a bind mount so we dont cp the entire repo for no reason
-# This is why we need --privileged
-mount --bind "/repo" "/tmp/$name-$version"
-tar -czvf "$HOME/rpmbuild/SOURCES/$name-$version.tar.gz" -- "$name-$version"
+cp "${pkg_file%.spec}.sysusers" \
+	"$HOME/rpmbuild/SOURCES/$name.sysusers"
 
 cd ~/rpmbuild/SPECS
 cp "$pkg_file" "$name.spec"
 sed -i "s/VERSION_NUMBER/$version/g" "$name.spec"
 
-# Build source and binary rpms
 rpmbuild -ba "$name.spec"
 
-arch="$(arch)"
-release="$(rpm --eval "$(get_property Release)")"
-fullname="$name-$version-$release"
-
 cd ~/rpmbuild
-
 mkdir -p "$pkg_base_dir/out"
 cp "SRPMS/$fullname.src.rpm" "$pkg_base_dir/out"
 cp "RPMS/$arch/$fullname.$arch.rpm" "$pkg_base_dir/out"

--- a/packages/rpm/package.spec
+++ b/packages/rpm/package.spec
@@ -1,38 +1,39 @@
-Name:           kbd-backlight
-Version:        VERSION_NUMBER
-Release:        1%{?dist}
-Summary:        Keyboard Backlight for the Legion Y720
+Name: kbd-backlight
+Version: VERSION_NUMBER
+Release: 1%{?dist}
+Summary: Keyboard backlight control for Lenovo Y720 laptop
+License: MIT
+URL: https://github.com/threadexio/Legion-Y720-Keyboard-Backlight
+Source0: %{name}-%{version}.tar.gz
+Source1: %{name}.sysusers
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: libconfig-devel
+BuildRequires: systemd-rpm-macros
+Requires: libconfig
 
-License:        MIT
-URL:            https://github.com/threadexio/Legion-Y720-Keyboard-Backlight
-Source0:        %{name}-VERSION_NUMBER.tar.gz
-
-BuildRequires:  gcc gcc-c++ cmake make libconfig-devel
-Requires:		libconfig
+%global source_date_epoch_from_changelog 0
 
 %description
-Simple C program to control the keyboard backlight on the Lenovo Legion Y720 
-
-%global debug_package %{nil}
+A simple C program to control the keyboard backlight on the Lenovo Y720 laptop.
 
 %prep
-%setup -q
+%autosetup
 
 %build
-/usr/bin/make all
+%make_build all
 
 %install
 %make_install PREFIX="/usr" distclean all install
+install -p -D -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
 
-%post
-/sbin/groupadd -r %name
-/sbin/setcap cap_dac_override+eip /usr/bin/kbd-backlight
-
-%postun
-/sbin/groupdel %name
+%pre
+%sysusers_create_compat %{SOURCE1}
 
 %files
 %license LICENSE
-/usr/bin/kbd-backlight
-/etc/kbd-backlight/backlight.conf
-/usr/share/kbd-backlight/backlight.conf.default
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %attr(0664,-,%{name}) %{_sysconfdir}/%{name}/backlight.conf
+%caps(cap_dac_override+eip) %{_bindir}/%{name}
+%{_datadir}/%{name}
+%{_sysusersdir}/%{name}.conf

--- a/packages/rpm/package.sysusers
+++ b/packages/rpm/package.sysusers
@@ -1,0 +1,1 @@
+g kbd-backlight - -


### PR DESCRIPTION
Prefer variables over hard-coded names in the Makefile.
Replace `docker --privileged` and `tar` with `git archive`.
Allocate the group declaratively with `sysusers` in RPM spec.
Fix the dubious ownership issue when using Git in Docker.
Fix the warning about missing changelog in RPM spec.